### PR TITLE
fix: variant 'link' outline removed

### DIFF
--- a/packages/button/stories/it-button.stories.ts
+++ b/packages/button/stories/it-button.stories.ts
@@ -51,11 +51,13 @@ const renderVariant = (args, defaultText) => {
       ...args,
       slot: slot ?? defaultText,
     })}
-    ${renderDefault({
-      ...args,
-      slot: slot ?? `${defaultText} outline`,
-      outline: true,
-    })}
+    ${args.variant !== 'link'
+      ? renderDefault({
+          ...args,
+          slot: slot ?? `${defaultText} outline`,
+          outline: true,
+        })
+      : ''}
   </div>`;
 };
 


### PR DESCRIPTION
Fixes #81

#### PR Checklist

<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->

- [x] My branch is up-to-date with the Upstream `main` branch.
- [x] The unit tests pass locally with my changes (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [x] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:

Rimosso l'esempio per variant="link" con outline perchè senza senso

#### Changes proposed in this Pull Request:

## <!-- You can use a few bullet points to describe some implementation changes proposed. For Example - feat: adding navbar component -->
