### PR TITLE
fix: link hover styles on dark bg

### DIFF
--- a/packages/button/styles/globals.scss
+++ b/packages/button/styles/globals.scss
@@ -7,6 +7,11 @@ it-button {
 .bg-dark {
   it-button::part(link) {
     --#{$prefix}btn-text-color: var(--#{$prefix}color-text-inverse);
+    &:hover,
+    &:focus {
+      --#{$prefix}color-link-hover: var(--#{$prefix}color-text-inverse);
+      text-decoration-thickness: 2px;
+    }
   }
 
   it-button::part(outline) {


### PR DESCRIPTION
Fixes #84 

#### PR Checklist

- [x] My branch is up-to-date with the Upstream `main` branch.
- [x] The unit tests pass locally with my changes (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [x] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:
Sistemato lo stile all'hover del pulsante con variante `link` su sfondo scuro. 