### PR TITLE
fix: removed default value for default i18n native attributes dir & l…

### DIFF
--- a/packages/i18n/src/mixins/localization.ts
+++ b/packages/i18n/src/mixins/localization.ts
@@ -49,9 +49,9 @@ const LocalizeMixin = <T extends Constructor<ReactiveControllerHost & HTMLElemen
     public localize: LocalizeController = new LocalizeController(this);
 
     // Provide default values to avoid definite assignment errors and avoid decorators
-    dir: string = '';
-
-    lang: string = '';
+    // commentati perchè danno problemi su React.js. Sono attributi nativi, e assegnare un valore di default a react da fastidio
+    // dir: string = '';
+    // lang: string = '';
 
     /**
      * Restituisce tutta l'utility di traduzione


### PR DESCRIPTION
…ang because causing problems with React and unnecessary

#### PR Checklist

<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->

- [ x] My branch is up-to-date with the Upstream `main` branch.
- [ x] The unit tests pass locally with my changes (if applicable).
- [ x] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [ x] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:
In react, l'inizializzazione dei web-components che utlizzano BaseLocalizedComponent e quindi il LocalizeMixin, davano errore in quanto per gli attributi nativi `dir` e `lang` era impostato un default a stringa vuota (''). L'impostazione di questo default, causava un conflitto nel ciclo di vita del componente che interferiva con il ciclo di react.
Dato che l'inizializzazione a stringa vuota di questi attributi non è necessaria, è stata commentata. 
